### PR TITLE
Fix line-number and context

### DIFF
--- a/config-highlight.cfg
+++ b/config-highlight.cfg
@@ -26,3 +26,7 @@ stdout-foreground =     #F8F8F2
 stdout-background =     #282A36
 stderr-foreground =     #FF5555
 stderr-background =     #282A36
+context-foreground =    #282A36
+context-background =    #F8F8F2
+linenumber-foreground = #F8F8F2
+linenumber-background = #282A36


### PR DESCRIPTION
### **Fix line-number and context highlights**

**Fix:** Add support for line numbers and context highlighting in IDLE Dracula theme

### **Description**

Previously, the Dracula theme for IDLE did not properly support line number and context highlighting.
This update adjusts the following color values to maintain consistency across the theme:

* `context-foreground`
* `context-background`
* `linenumber-foreground`
* `linenumber-background`

### **Screenshots**

#### Before

<img width="503" height="580" alt="Previous Screenshot" src="https://github.com/user-attachments/assets/d17bc49c-fdd0-4237-aa06-fdc134cd6baf" />


#### After

<img width="503" height="580" alt="Updated Screenshot" src="https://github.com/user-attachments/assets/5ec215a4-a29f-4799-993e-376fd4c44534" />


### **Notes**

* Ensures consistent styling across context highlights and line numbers.
* Matches Dracula’s visual design principles.